### PR TITLE
feat(redux-session): remember login

### DIFF
--- a/packages/tpl-cra-redux/src/containers/login/index.js
+++ b/packages/tpl-cra-redux/src/containers/login/index.js
@@ -17,7 +17,9 @@ export default class Login extends React.PureComponent {
     const { from = { pathname: "/" } } = this.props.location.state || {};
     this.props.form.validateFields((err, values) => {
       if (!err) {
-        this.props.dispatch(login({ body: values }, { from }));
+        this.props.dispatch(
+          login({ body: values }, { from, remember: values.remember })
+        );
       }
     });
   };


### PR DESCRIPTION
新增记住密码功能

参考 tpl-cra-redux 中，通过 meta 中传递 remember 参数，来告诉 redux-session 是否记住登录状态。

submit 方法中

```
// 记住登录状态
login(payload, { remember: true })

// 不记住登录状态
login(payload, { remember: false })
```